### PR TITLE
Feat: DIR Entity, Repository, Test 추가 (연관관계 매핑 전)

### DIFF
--- a/src/main/java/com/mergedoc/backend/dir/entity/DIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/DIR.java
@@ -1,0 +1,26 @@
+package com.mergedoc.backend.dir.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DIR extends InDIR{
+
+    @Id @GeneratedValue
+    private Long id;
+
+    //    member 구현 후 연관관계 셋팅 필요
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private DIR parent;
+
+    @Builder
+    public DIR(DIR parent) {
+        this.parent = parent;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/dir/entity/InDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/InDIR.java
@@ -14,7 +14,6 @@ public abstract class InDIR extends BaseEntity {
     public void setPath(String path) {
         this.path = path;
     }
-
     public void setName(String name) {
         this.name = name;
     }

--- a/src/main/java/com/mergedoc/backend/dir/entity/InDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/InDIR.java
@@ -1,0 +1,21 @@
+package com.mergedoc.backend.dir.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.Getter;
+
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@MappedSuperclass
+public abstract class InDIR extends BaseEntity {
+    private String path;
+    private String name;
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/dir/entity/PageInDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/PageInDIR.java
@@ -1,0 +1,33 @@
+package com.mergedoc.backend.dir.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageInDIR extends InDIR{
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dir_id")
+    private DIR dir;
+
+//    Page Entity 추가 후 연관관계 추가
+
+    public void setDIR(DIR dir) {
+        this.dir = dir;
+    }
+
+    @Builder
+    public PageInDIR(DIR dir) {
+        this.dir = dir;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/dir/entity/PageInDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/PageInDIR.java
@@ -22,10 +22,6 @@ public class PageInDIR extends InDIR{
 
 //    Page Entity 추가 후 연관관계 추가
 
-    public void setDIR(DIR dir) {
-        this.dir = dir;
-    }
-
     @Builder
     public PageInDIR(DIR dir) {
         this.dir = dir;

--- a/src/main/java/com/mergedoc/backend/dir/entity/UnitInDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/UnitInDIR.java
@@ -24,10 +24,6 @@ public class UnitInDIR extends InDIR{
 //    Unit Entity 추가 후 연관관계 추가
 
 
-    public void setDir(DIR dir) {
-        this.dir = dir;
-    }
-
     @Builder
     public UnitInDIR(DIR dir) {
         this.dir = dir;

--- a/src/main/java/com/mergedoc/backend/dir/entity/UnitInDIR.java
+++ b/src/main/java/com/mergedoc/backend/dir/entity/UnitInDIR.java
@@ -1,0 +1,35 @@
+package com.mergedoc.backend.dir.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnitInDIR extends InDIR{
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dir_id")
+    private DIR dir;
+
+//    Unit Entity 추가 후 연관관계 추가
+
+
+    public void setDir(DIR dir) {
+        this.dir = dir;
+    }
+
+    @Builder
+    public UnitInDIR(DIR dir) {
+        this.dir = dir;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/dir/repository/DIRRepository.java
+++ b/src/main/java/com/mergedoc/backend/dir/repository/DIRRepository.java
@@ -1,0 +1,81 @@
+package com.mergedoc.backend.dir.repository;
+
+import com.mergedoc.backend.dir.entity.DIR;
+import com.mergedoc.backend.dir.entity.InDIR;
+import com.mergedoc.backend.dir.entity.PageInDIR;
+import com.mergedoc.backend.dir.entity.UnitInDIR;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DIRRepository {
+
+    private final EntityManager em;
+
+    public void saveDIR(DIR dir) {
+        em.persist(dir);
+    }
+    public void saveUnitInDIR(UnitInDIR unitInDIR) {em.persist(unitInDIR);}
+    public void savePageInDIR(PageInDIR pageInDir) {
+        em.persist(pageInDir);
+    }
+
+    public List<InDIR> findAllByPath(String path) {
+        List<InDIR> findFiles = new ArrayList<>();
+
+        findFiles.addAll(findDIRsByPath(path));
+        findFiles.addAll(findPagesByPath(path));
+        findFiles.addAll(findUnitsByPath(path));
+
+        return findFiles;
+    }
+
+    public List<DIR> findDIRsByPath(String path) {
+        return em.createQuery("select d from DIR d where d.path = :path", DIR.class)
+                .setParameter("path", path)
+                .getResultList();
+    }
+
+    public DIR findDIRByPathAndName(String path, String name) {
+        return em.createQuery("select d from DIR d where " +
+                        "d.path = :path and d.name = :name", DIR.class)
+                .setParameter("path", path)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+
+
+    public List<UnitInDIR> findUnitsByPath(String path) {
+        return em.createQuery("select u from UnitInDIR u where u.path = :path", UnitInDIR.class)
+                .setParameter("path", path)
+                .getResultList();
+    }
+
+    public UnitInDIR findUnitByPathAndName(String path, String name) {
+        return em.createQuery("select u from UnitInDIR u where " +
+                        "u.path = :path and u.name = :name", UnitInDIR.class)
+                .setParameter("path", path)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+
+    public List<PageInDIR> findPagesByPath(String path) {
+        return em.createQuery("select p from PageInDIR p where p.path = :path", PageInDIR.class)
+                .setParameter("path", path)
+                .getResultList();
+    }
+
+    public PageInDIR findPageByPathAndName(String path, String name) {
+        return em.createQuery("select p from PageInDIR p where " +
+                        "p.path = :path and p.name = :name", PageInDIR.class)
+                .setParameter("path", path)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+}

--- a/src/main/java/com/mergedoc/backend/dir/repository/DIRRepository.java
+++ b/src/main/java/com/mergedoc/backend/dir/repository/DIRRepository.java
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -42,12 +43,13 @@ public class DIRRepository {
                 .getResultList();
     }
 
-    public DIR findDIRByPathAndName(String path, String name) {
+    public Optional<DIR> findDIRByPathAndName(String path, String name) {
         return em.createQuery("select d from DIR d where " +
                         "d.path = :path and d.name = :name", DIR.class)
                 .setParameter("path", path)
                 .setParameter("name", name)
-                .getSingleResult();
+                .getResultList()
+                .stream().findFirst();
     }
 
 
@@ -57,12 +59,13 @@ public class DIRRepository {
                 .getResultList();
     }
 
-    public UnitInDIR findUnitByPathAndName(String path, String name) {
+    public Optional<UnitInDIR> findUnitByPathAndName(String path, String name) {
         return em.createQuery("select u from UnitInDIR u where " +
                         "u.path = :path and u.name = :name", UnitInDIR.class)
                 .setParameter("path", path)
                 .setParameter("name", name)
-                .getSingleResult();
+                .getResultList()
+                .stream().findFirst();
     }
 
     public List<PageInDIR> findPagesByPath(String path) {
@@ -71,11 +74,13 @@ public class DIRRepository {
                 .getResultList();
     }
 
-    public PageInDIR findPageByPathAndName(String path, String name) {
+    public Optional<PageInDIR> findPageByPathAndName(String path, String name) {
         return em.createQuery("select p from PageInDIR p where " +
                         "p.path = :path and p.name = :name", PageInDIR.class)
                 .setParameter("path", path)
                 .setParameter("name", name)
-                .getSingleResult();
+                .getResultList()
+                .stream().findFirst();
     }
+
 }

--- a/src/test/java/com/mergedoc/backend/repository/DIRTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/DIRTest.java
@@ -4,6 +4,7 @@ import com.mergedoc.backend.dir.entity.DIR;
 import com.mergedoc.backend.dir.entity.PageInDIR;
 import com.mergedoc.backend.dir.entity.UnitInDIR;
 import com.mergedoc.backend.dir.repository.DIRRepository;
+import com.mergedoc.backend.exceptions.NotFoundException;
 import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,8 @@ public class DIRTest {
 
         String createName = "testDIR";
 
-        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName)
+                .orElseThrow(() -> new NotFoundException("디렉토리를 찾을 수 없습니다."));
 
         DIR createdDIR = DIR.builder().parent(parentDIR).build();
         createdDIR.setPath(rootPath+rootName+"/");
@@ -52,7 +54,8 @@ public class DIRTest {
 
     @Test
     public void findUnit() {
-        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName)
+                .orElseThrow(() -> new NotFoundException("디렉토리를 찾을 수 없습니다."));
 
         String childPath = rootPath+rootName+"/";
 
@@ -66,14 +69,16 @@ public class DIRTest {
 
         dirRepository.saveUnitInDIR(createUnitInDIR);
 
-        UnitInDIR findUnit = dirRepository.findUnitByPathAndName(childPath, "testUnit");
+        UnitInDIR findUnit = dirRepository.findUnitByPathAndName(childPath, "testUnit")
+                .orElseThrow(() -> new NotFoundException("유닛을 찾을 수 없습니다."));
 
         assertThat(findUnit).isEqualTo(createUnitInDIR);
     }
 
     @Test
     public void findPage() {
-        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName)
+                .orElseThrow(() -> new NotFoundException("디렉토리를 찾을 수 없습니다."));
 
         String childPath = rootPath+rootName+"/";
 
@@ -87,14 +92,16 @@ public class DIRTest {
 
         dirRepository.savePageInDIR(createPageInDIR);
 
-        PageInDIR findUnit = dirRepository.findPageByPathAndName(childPath, "testPage");
+        PageInDIR findUnit = dirRepository.findPageByPathAndName(childPath, "testPage")
+                .orElseThrow(() -> new NotFoundException("페이지를 찾을 수 없습니다."));
 
         assertThat(findUnit).isEqualTo(createPageInDIR);
     }
 
     @Test
     public void findDIR() {
-        DIR findDIR = dirRepository.findDIRByPathAndName("/root/", "testDIR");
+        DIR findDIR = dirRepository.findDIRByPathAndName("/root/", "testDIR")
+                .orElseThrow(() -> new NotFoundException("디렉토리를 찾을 수 없습니다."));
 
         assertThat(findDIR).isEqualTo(dir);
     }

--- a/src/test/java/com/mergedoc/backend/repository/DIRTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/DIRTest.java
@@ -1,0 +1,103 @@
+package com.mergedoc.backend.repository;
+
+import com.mergedoc.backend.dir.entity.DIR;
+import com.mergedoc.backend.dir.entity.PageInDIR;
+import com.mergedoc.backend.dir.entity.UnitInDIR;
+import com.mergedoc.backend.dir.repository.DIRRepository;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class DIRTest {
+
+    @Autowired
+    private DIRRepository dirRepository;
+
+    DIR dir;
+
+    String rootPath = "/";
+    String rootName = "root";
+
+    @BeforeEach
+    public void createRoot() {
+        DIR rootDIR = DIR.builder().build();
+
+        rootDIR.setName(rootName);
+        rootDIR.setPath(rootPath);
+
+        dirRepository.saveDIR(rootDIR);
+
+        String createName = "testDIR";
+
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+
+        DIR createdDIR = DIR.builder().parent(parentDIR).build();
+        createdDIR.setPath(rootPath+rootName+"/");
+        createdDIR.setName(createName);
+
+        dirRepository.saveDIR(createdDIR);
+
+        this.dir = createdDIR;
+
+    }
+
+    @Test
+    public void findUnit() {
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+
+        String childPath = rootPath+rootName+"/";
+
+        UnitInDIR createUnitInDIR = UnitInDIR.builder()
+                .dir(parentDIR)
+                .build();
+
+        createUnitInDIR.setPath(childPath);
+        createUnitInDIR.setName("testUnit");
+//        Unit 연관관계 추가 필요
+
+        dirRepository.saveUnitInDIR(createUnitInDIR);
+
+        UnitInDIR findUnit = dirRepository.findUnitByPathAndName(childPath, "testUnit");
+
+        assertThat(findUnit).isEqualTo(createUnitInDIR);
+    }
+
+    @Test
+    public void findPage() {
+        DIR parentDIR = dirRepository.findDIRByPathAndName(rootPath, rootName);
+
+        String childPath = rootPath+rootName+"/";
+
+        PageInDIR createPageInDIR = PageInDIR.builder()
+                .dir(parentDIR)
+                .build();
+
+        createPageInDIR.setPath(childPath);
+        createPageInDIR.setName("testPage");
+//        Unit 연관관계 추가 필요
+
+        dirRepository.savePageInDIR(createPageInDIR);
+
+        PageInDIR findUnit = dirRepository.findPageByPathAndName(childPath, "testPage");
+
+        assertThat(findUnit).isEqualTo(createPageInDIR);
+    }
+
+    @Test
+    public void findDIR() {
+        DIR findDIR = dirRepository.findDIRByPathAndName("/root/", "testDIR");
+
+        assertThat(findDIR).isEqualTo(dir);
+    }
+
+
+}


### PR DESCRIPTION
DIR Entity, Repository, Test 추가하였습니다.

Repository 는 생성, 조회만 추가하였고, 현재 PageInDIR, UnitInDIR 연관관계 매핑은 포함되어 있지 않습니다.

기존 설계에서 한 가지 수정한 것은 클라이언트에게 제공될 탐색 경로가 필요하다고 판단되어 path 를 추가했습니다.

부모 DIR 이 /root/parentDIR 의 경로에 존재하고, 해당 경로에 sample.unit 을 추가하고 싶다면

**parent path** : /root/ 
**parent DIR** Name : parentDIR

**child path** : parent path + parent DIR Name + "/"
**child unit name** : sample 

이 됩니다.

모든 DIR 내 조회 생성 로직은 create(child path, child unit name) 로 이루어져 있습니다.