### PR TITLE
Feat: SharePage Entity, Repository, Test 추가 (연관관계 매핑 전)

### DIFF
--- a/src/main/java/com/mergedoc/backend/share/entity/SharedPage.java
+++ b/src/main/java/com/mergedoc/backend/share/entity/SharedPage.java
@@ -1,0 +1,42 @@
+package com.mergedoc.backend.share.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+
+import com.mergedoc.backend.page.entity.Page;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SharedPage extends BaseEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    private String url;
+
+    private LocalDateTime expiredDate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "page_id")
+    private Page page;
+
+//    Member entity 추가 후 연관관계 추가
+
+    @Builder
+    public SharedPage(String name, String url, LocalDateTime expiredDate, Page page) {
+        this.name = name;
+        this.url = url;
+        this.expiredDate = expiredDate;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/share/repository/ShareRepository.java
+++ b/src/main/java/com/mergedoc/backend/share/repository/ShareRepository.java
@@ -1,0 +1,39 @@
+package com.mergedoc.backend.share.repository;
+
+import com.mergedoc.backend.share.entity.SharedPage;
+import com.mergedoc.backend.share.util.URLGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class ShareRepository {
+
+    private final EntityManager em;
+
+    public void saveSharedPage(SharedPage sharedPage) {em.persist(sharedPage);}
+
+    public SharedPage findSharedPageByURL(String findURL) {
+        return em.createQuery("select s from SharedPage s " +
+                "where s.url = :url", SharedPage.class)
+                .setParameter("url", findURL)
+                .getSingleResult();
+    }
+
+    public void deleteSharedPage(String deleteURL) {
+        em.createQuery("delete from SharedPage p " +
+                "where p.url = :url")
+                .setParameter("url", deleteURL)
+                .executeUpdate();
+    }
+
+    public void deleteExpiredSharedPage() {
+        em.createQuery("delete from SharedPage p " +
+                "where p.expiredDate < :dateTime")
+                .setParameter("dateTime", LocalDateTime.now())
+                .executeUpdate();
+    }
+}

--- a/src/main/java/com/mergedoc/backend/share/repository/ShareRepository.java
+++ b/src/main/java/com/mergedoc/backend/share/repository/ShareRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,11 +17,12 @@ public class ShareRepository {
 
     public void saveSharedPage(SharedPage sharedPage) {em.persist(sharedPage);}
 
-    public SharedPage findSharedPageByURL(String findURL) {
+    public Optional<SharedPage> findSharedPageByURL(String findURL) {
         return em.createQuery("select s from SharedPage s " +
                 "where s.url = :url", SharedPage.class)
                 .setParameter("url", findURL)
-                .getSingleResult();
+                .getResultList()
+                .stream().findFirst();
     }
 
     public void deleteSharedPage(String deleteURL) {

--- a/src/main/java/com/mergedoc/backend/share/util/URLGenerator.java
+++ b/src/main/java/com/mergedoc/backend/share/util/URLGenerator.java
@@ -1,0 +1,37 @@
+package com.mergedoc.backend.share.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class URLGenerator {
+
+    public String generateURLWithNumeric(int length) {
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(length)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+    public String generateURL(int length) {
+        int leftLimit = 97; // numeral '0'
+        int rightLimit = 122; // letter 'z'
+
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(length)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+
+}

--- a/src/test/java/com/mergedoc/backend/repository/ShareRepositoryTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/ShareRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.mergedoc.backend.repository;
+
+import com.mergedoc.backend.page.entity.Page;
+import com.mergedoc.backend.share.entity.SharedPage;
+import com.mergedoc.backend.share.repository.ShareRepository;
+import com.mergedoc.backend.share.util.URLGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class ShareRepositoryTest {
+
+    @Autowired
+    private ShareRepository shareRepository;
+
+//    @Autowired
+//    private DIRRepository dirRepository;
+
+    @Autowired
+    private URLGenerator urlGenerator;
+
+    @Test
+    public void findSharePage() {
+        String url = urlGenerator.generateURLWithNumeric(20);
+
+//        Page page = dirRepository.findPageByPathAndName("/root/", "test").getPage();
+
+        SharedPage sharedPage = SharedPage.builder()
+                .expiredDate(LocalDateTime.now().plusDays(7))
+                .url(url)
+                .build();
+
+        shareRepository.saveSharedPage(sharedPage);
+
+        SharedPage findPage = shareRepository.findSharedPageByURL(url);
+
+        assertThat(findPage).isEqualTo(sharedPage);
+    }
+
+    @Test
+    public void deleteExpiredSharePage() {
+        String url = urlGenerator.generateURLWithNumeric(20);
+
+        SharedPage sharedPage = SharedPage.builder()
+                .expiredDate(LocalDateTime.now().minusDays(7))
+                .url(url)
+                .build();
+
+        shareRepository.saveSharedPage(sharedPage);
+
+        shareRepository.deleteExpiredSharedPage();
+
+        try {
+            shareRepository.findSharedPageByURL(url);
+            fail("삭제 실패");
+        } catch (Exception e) {
+        }
+    }
+}

--- a/src/test/java/com/mergedoc/backend/repository/ShareRepositoryTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/ShareRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.mergedoc.backend.repository;
 
+import com.mergedoc.backend.exceptions.NotFoundException;
 import com.mergedoc.backend.page.entity.Page;
 import com.mergedoc.backend.share.entity.SharedPage;
 import com.mergedoc.backend.share.repository.ShareRepository;
@@ -39,7 +40,8 @@ public class ShareRepositoryTest {
 
         shareRepository.saveSharedPage(sharedPage);
 
-        SharedPage findPage = shareRepository.findSharedPageByURL(url);
+        SharedPage findPage = shareRepository.findSharedPageByURL(url)
+                .orElseThrow(() -> new NotFoundException("공유 페이지를 찾을 수 없습니다."));
 
         assertThat(findPage).isEqualTo(sharedPage);
     }


### PR DESCRIPTION
SharePage Entity, Repository, Test 추가하였습니다.

1. SharePage 에 대해서 생성, 조회, 삭제를 열어두었습니다.
2. expiredDate 는 생성 후 7일로 제한했고, 날짜가 지난 페이지를 제거하는 로직을 추가했습니다.
3. Page, Member entity 추가 후 연관관계 매핑과 로직 추가가 필요합니다.

SharePage 의 경우에는 랜덤으로 생성되는 URL 주소로 매핑되게 구현을 했고, 해당 URL 을 생성하는 URLGenerator Component 를 추가했습니다.