### PR TITLE
Feat: Page Domain Entity, Repository, Test 추가 (연관관계 매핑 전)

### DIFF
--- a/src/main/java/com/mergedoc/backend/page/entity/Page.java
+++ b/src/main/java/com/mergedoc/backend/page/entity/Page.java
@@ -1,0 +1,31 @@
+package com.mergedoc.backend.page.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Page extends BaseEntity{
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public void changeName(String changeName) {
+        this.name = changeName;
+    }
+
+    @Builder
+    public Page(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/page/entity/Page.java
+++ b/src/main/java/com/mergedoc/backend/page/entity/Page.java
@@ -20,10 +20,6 @@ public class Page extends BaseEntity{
 
     private String name;
 
-    public void changeName(String changeName) {
-        this.name = changeName;
-    }
-
     @Builder
     public Page(String name) {
         this.name = name;

--- a/src/main/java/com/mergedoc/backend/page/entity/PageUnit.java
+++ b/src/main/java/com/mergedoc/backend/page/entity/PageUnit.java
@@ -1,0 +1,33 @@
+package com.mergedoc.backend.page.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageUnit {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "page_id")
+    private Page page;
+
+// Unit 연관관계 매핑 추가
+
+
+    @Builder
+    public PageUnit(String name, Page page) {
+        this.name = name;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/page/repository/PageRepository.java
+++ b/src/main/java/com/mergedoc/backend/page/repository/PageRepository.java
@@ -1,0 +1,37 @@
+package com.mergedoc.backend.page.repository;
+
+import com.mergedoc.backend.page.entity.Page;
+import com.mergedoc.backend.page.entity.PageUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PageRepository {
+
+    private final EntityManager em;
+
+    public void savePage(Page page) {em.persist(page);}
+
+    public void savePageUnit(PageUnit pageUnit) {em.persist(pageUnit);}
+
+    public void deletePage(Page page) {em.remove(page);}
+
+    public void deletePageUnit(PageUnit pageUnit) {em.remove(pageUnit);}
+
+    public void changePageName(Page page, String name) {
+        page.changeName(name);
+    }
+
+    public Page findPageById(Long id) {return em.find(Page.class, id);}
+
+    public List<PageUnit> findPageUnitsByPage(Page page) {
+        return em.createQuery("select u from PageUnit u " +
+                "where u.page = :page", PageUnit.class)
+                .setParameter("page", page)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/mergedoc/backend/page/repository/PageRepository.java
+++ b/src/main/java/com/mergedoc/backend/page/repository/PageRepository.java
@@ -22,10 +22,6 @@ public class PageRepository {
 
     public void deletePageUnit(PageUnit pageUnit) {em.remove(pageUnit);}
 
-    public void changePageName(Page page, String name) {
-        page.changeName(name);
-    }
-
     public Page findPageById(Long id) {return em.find(Page.class, id);}
 
     public List<PageUnit> findPageUnitsByPage(Page page) {

--- a/src/test/java/com/mergedoc/backend/repository/PageRepositoryTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/PageRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.mergedoc.backend.repository;
+
+import com.mergedoc.backend.page.entity.Page;
+import com.mergedoc.backend.page.entity.PageUnit;
+import com.mergedoc.backend.page.repository.PageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class PageRepositoryTest {
+
+    @Autowired
+    private PageRepository pageRepository;
+
+
+    Page page;
+
+    @BeforeEach
+    public void createPage() {
+        page = Page.builder()
+                .name("sample_page")
+                .build();
+
+        pageRepository.savePage(page);
+
+        //        DIR 에 추가
+
+    }
+
+    @Test
+    public void findPage() {
+        Page findPage = pageRepository.findPageById(page.getId());
+
+        assertThat(findPage).isEqualTo(page);
+    }
+
+    @Test
+    public void addPageUnit() {
+//        Unit 생성
+
+        PageUnit pageUnit = PageUnit.builder()
+                .page(page)
+                .build();
+//        Unit 매핑
+
+        pageRepository.savePageUnit(pageUnit);
+
+        List<PageUnit> findPageUnit = pageRepository.findPageUnitsByPage(page);
+
+        assertThat(findPageUnit.get(0)).isEqualTo(pageUnit);
+    }
+
+    @Test
+    public void changePageName() {
+        pageRepository.changePageName(page, "sample_page2");
+
+        assertThat(page.getName()).isNotEqualTo("sample_page");
+    }
+}

--- a/src/test/java/com/mergedoc/backend/repository/PageRepositoryTest.java
+++ b/src/test/java/com/mergedoc/backend/repository/PageRepositoryTest.java
@@ -57,11 +57,4 @@ public class PageRepositoryTest {
 
         assertThat(findPageUnit.get(0)).isEqualTo(pageUnit);
     }
-
-    @Test
-    public void changePageName() {
-        pageRepository.changePageName(page, "sample_page2");
-
-        assertThat(page.getName()).isNotEqualTo("sample_page");
-    }
 }


### PR DESCRIPTION
## PR 요약 
FEAT : Page Domain Entity, Repository, Test 추가하였습니다.

## 변경 사항
1. Page, Page Unit 에 대하여 생성, 삭제를 열어두었습니다.
2. Page 를 통해 Page Unit List 조회가 가능합니다.
3. Page 의 이름을 수정할 수 있습니다.

## 참고 사항
1. Page Unit 쪽 Unit 연관관계는 빠져있는 상태입니다.
2. Page Unit 순서 표현을 어떻게 할지 토의가 필요합니다.

