### PR TITLE
Feat: Unit Domain DoubleUnit, MergedUnit, Repository, Test 추가

### DIFF
--- a/src/main/java/com/mergedoc/backend/unit/entity/DoubleUnit.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/DoubleUnit.java
@@ -1,0 +1,33 @@
+package com.mergedoc.backend.unit.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DoubleUnit extends Unit{
+
+    @OneToMany(mappedBy = "doubleUnit", cascade = CascadeType.ALL)
+    private List<MappedUnit> mappedUnitList = new ArrayList<>();
+
+    @Builder
+    public DoubleUnit(String title){
+        this.setTitle(title);
+        this.setForm(Form.Double);
+    }
+
+    //==연관관계 편의 메서드==//
+    public void addMappedUnit(MappedUnit mappedUnit){
+        mappedUnitList.add(mappedUnit);
+        mappedUnit.builder().doubleUnit(this);
+    }
+
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/Form.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/Form.java
@@ -1,0 +1,7 @@
+package com.mergedoc.backend.unit.entity;
+
+public enum Form {
+    Single,
+    Double,
+    Merged
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/MappedUnit.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/MappedUnit.java
@@ -1,0 +1,65 @@
+package com.mergedoc.backend.unit.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MappedUnit extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "mapped_id")
+    private Long id;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Form form;
+
+    private int orders;
+
+    @Builder
+    public MappedUnit( String title, Form form, int orders, DoubleUnit doubleUnit, MergedUnit mergedUnit, Unit originUnit) {
+        this.title = title;
+        this.form = form;
+        this.orders = orders;
+        this.doubleUnit = doubleUnit;
+        this.mergedUnit = mergedUnit;
+        this.originUnit = originUnit;
+    }
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "double_id")
+    private DoubleUnit doubleUnit;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "merged_id")
+    private MergedUnit mergedUnit;
+
+    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "origin_id")
+    private Unit originUnit; //single, double
+
+/*
+    //==연관관계 편의 메서드==//
+    public void addDoubleUnit(DoubleUnit doubleUnit){
+        this.doubleUnit = doubleUnit;
+        doubleUnit.getMappedUnitList().add(this);
+    }
+
+    public void addMergedUnit(MergedUnit mergedUnit){
+        this.mergedUnit = mergedUnit;
+        mergedUnit.getMappedUnitList().add(this);
+    }
+*/
+
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/MergedUnit.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/MergedUnit.java
@@ -1,0 +1,33 @@
+package com.mergedoc.backend.unit.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MergedUnit extends Unit{
+
+    @OneToMany(mappedBy = "mergedUnit", cascade = CascadeType.ALL)
+    private List<MappedUnit> mappedUnitList = new ArrayList<>();
+
+    @Builder
+    public MergedUnit(String title){
+        this.setTitle(title);
+        this.setForm(Form.Merged);
+    }
+
+    //==연관관계 편의 메서드==//
+    public void addMappedUnit(MappedUnit mappedUnit){
+        mappedUnitList.add(mappedUnit);
+        mappedUnit.builder().mergedUnit(this);
+    }
+
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/Tag.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/Tag.java
@@ -1,0 +1,29 @@
+package com.mergedoc.backend.unit.entity;
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "tag_id")
+    private Long id;
+
+    private String content;
+
+    private int count;
+
+    @Builder
+    public Tag(String content, int count) {
+        this.content = content;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/Type.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/Type.java
@@ -1,0 +1,9 @@
+package com.mergedoc.backend.unit.entity;
+
+public enum Type {
+    Plain,
+    Project,
+    QnA,
+    Double,
+    Merged
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/Unit.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/Unit.java
@@ -1,0 +1,31 @@
+package com.mergedoc.backend.unit.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class Unit extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "unit_id")
+    private Long id;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+}

--- a/src/main/java/com/mergedoc/backend/unit/entity/UnitTag.java
+++ b/src/main/java/com/mergedoc/backend/unit/entity/UnitTag.java
@@ -1,0 +1,34 @@
+package com.mergedoc.backend.unit.entity;
+
+import com.mergedoc.backend.Base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnitTag extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "unit_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "unit_id")
+    private Unit unit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+    @Builder
+    public UnitTag(Unit unit, Tag tag){
+        this.unit = unit;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/mergedoc/backend/unit/repository/UnitRepository.java
+++ b/src/main/java/com/mergedoc/backend/unit/repository/UnitRepository.java
@@ -1,0 +1,68 @@
+package com.mergedoc.backend.unit.repository;
+
+import com.mergedoc.backend.unit.entity.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Table;
+
+
+@Repository
+@RequiredArgsConstructor
+public class UnitRepository {
+
+    private final EntityManager em;
+
+    //저장
+
+    //public void saveSingleUnit(SingleUnit singleUnit){em.persist(singleUnit);}
+
+    public void saveDoubleUnit(DoubleUnit doubleUnit){em.persist(doubleUnit);}
+
+    public void saveMergedUnit(MergedUnit mergedUnit){em.persist(mergedUnit);}
+
+    public void saveMappedUnit(MappedUnit mappedUnit){em.persist(mappedUnit);}
+
+    public void saveTag(Tag tag){em.persist(tag);}
+
+    public void saveUnitTag(UnitTag unitTag){em.persist(unitTag);}
+
+    //조회
+    /*public SingleUnit findSingleUnit(Long singleUnitId){
+        return em.find(singleUnitId);
+    }*/
+    public DoubleUnit findDoubleUnit(Long doubleUnitId){
+        return em.find(DoubleUnit.class, doubleUnitId);
+    }
+
+    public MergedUnit findMergedUnit(Long mergedUnitId){
+        return em.find(MergedUnit.class, mergedUnitId);
+    }
+
+    public MappedUnit findMappedUnit(Long mappedUnitId){
+        return em.find(MappedUnit.class, mappedUnitId);
+    }
+
+    public Tag findTag(Long tagId){
+        return em.find(Tag.class, tagId);
+    }
+
+    public UnitTag findUnitTag(Long unitTagId){
+        return em.find(UnitTag.class,unitTagId);
+    }
+
+    //삭제
+    //public void deleteSingleUnit(SingleUnit singleUnit){em.remove(singleUnit);}
+
+    public void deleteDoubleUnit(DoubleUnit doubleUnit){em.remove(doubleUnit);}
+
+    public void deleteMergedUnit(MergedUnit mergedUnit){em.remove(mergedUnit);}
+
+    public void deleteMappedUnit(MappedUnit mappedUnit){em.remove(mappedUnit);}
+
+    public void deleteTag(Tag tag){em.remove(tag);}
+
+    public void deleteUnitTag(UnitTag unitTag){em.remove(unitTag);}
+
+}

--- a/src/test/java/com/mergedoc/backend/unit/repository/UnitRepositoryTest.java
+++ b/src/test/java/com/mergedoc/backend/unit/repository/UnitRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.mergedoc.backend.unit.repository;
+
+import com.mergedoc.backend.unit.entity.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+@SpringBootTest
+@Transactional
+class UnitRepositoryTest {
+
+    @Autowired UnitRepository unitRepository;
+    Long mergedUnitId;
+
+    // Single Unit 필요
+/*
+   @Test
+   void 더블유닛_저장() {
+       // given
+       DoubleUnit doubleUnit = DoubleUnit.builder().build();
+       SingleUnit singleUnit1 = SingleUnit.builder().title("single1").build();
+       SingleUnit singleUnit2 = SingleUnit.builder().title("single2").build();
+       MappedUnit mappedUnit1 = MappedUnit.builder()
+               .originUnit(singleUnit1)
+               .form(Form.Double)
+               .orders(1).build();
+       MappedUnit mappedUnit2 = MappedUnit.builder()
+               .originUnit(singleUnit2)
+               .form(Form.Double)
+               .orders(2).build();
+       doubleUnit.addMappedUnit(mappedUnit1);
+       doubleUnit.addMappedUnit(mappedUnit2);
+
+       // when
+       unitRepository.saveDoubleUnit(doubleUnit);
+       Long doubleUnitId = doubleUnit.getId();
+       DoubleUnit getDoubleUnit = unitRepository.findDoubleUnit(doubleUnitId);
+
+       // then
+       assertEquals("저장된 유닛의 Form의 타입은 Double.",Form.Double,getDoubleUnit.getForm());
+       assertEquals("더블 유닛을 통해 싱글 유닛의 정보를 가져옵니다.","single11",
+               getDoubleUnit.getMappedUnitList().get(0).getOriginUnit().getTitle());
+   }
+   @Test
+   void 머지드유닛_저장() {
+       // given
+       DoubleUnit doubleUnit = DoubleUnit.builder().title("double1").build();
+       SingleUnit singleUnit1 = SingleUnit.builder().title("single1").build();
+       SingleUnit singleUnit2 = SingleUnit.builder().title("single2").build();
+       MappedUnit mappedUnit1 = MappedUnit.builder()
+               .originUnit(singleUnit1)
+               .form(Form.Double)
+               .orders(1).build();
+       MappedUnit mappedUnit2 = MappedUnit.builder()
+               .originUnit(singleUnit2)
+               .form(Form.Double)
+               .orders(2).build();
+       doubleUnit.addMappedUnit(mappedUnit1);
+       doubleUnit.addMappedUnit(mappedUnit2);
+
+       MergedUnit mergedUnit = MergedUnit.builder().build();
+       SingleUnit singleUnit3 = SingleUnit.builder().title("single3").build();
+       MappedUnit mappedUnit3 = MappedUnit.builder()
+               .mergedUnit(mergedUnit)
+               .originUnit(singleUnit3)
+               .form(Form.Merged).build();
+       MappedUnit mappedUnit4 = MappedUnit.builder()
+               .mergedUnit(mergedUnit)
+               .originUnit(doubleUnit)
+               .form(Form.Merged).build();
+       mergedUnit.addMappedUnit(mappedUnit3);
+       mergedUnit.addMappedUnit(mappedUnit4);
+
+       // when
+       unitRepository.saveMergedUnit(mergedUnit);
+       Long doubleUnitId = doubleUnit.getId();
+       mergedUnitId = mergedUnit.getId();
+       DoubleUnit getDouble = unitRepository.findDoubleUnit(doubleUnitId);
+       MergedUnit getMerged = unitRepository.findMergedUnit(mergedUnitId);
+
+       // then
+       assertEquals("저장된 유닛의 Form의 타입은 Merged",Form.Merged,getMerged.getForm());
+       assertEquals("Merged유닛을 통해 싱글유닛의 정보를 가져옵니다.",singleUnit3.getTitle(),
+               getMerged.getMappedUnitList().get(0).getOriginUnit().getTitle());
+       assertEquals("Merged유닛을 통해 더블유닛의 정보를 가져옵니다.",getDouble.getTitle(),
+               getMerged.getMappedUnitList().get(1).getOriginUnit().getTitle());
+
+       */
+/**
+        * 유닛 삭제
+        *//*
+
+       //unitRepository.deleteMergedUnit(mergedUnit);
+   }
+*/
+
+   @Test
+   void 태그_저장() {
+       // given
+       DoubleUnit doubleUnit = DoubleUnit.builder().title("double").build();
+       Tag tag = Tag.builder().content("network").count(1).build();
+       UnitTag unitTag = UnitTag.builder().tag(tag).unit(doubleUnit).build();
+       unitRepository.saveTag(tag);
+       unitRepository.saveDoubleUnit(doubleUnit);
+       unitRepository.saveUnitTag(unitTag);
+
+       // when
+       Long unitTagId = unitTag.getId();
+       UnitTag getUnitTag = unitRepository.findUnitTag(unitTagId);
+
+       // then
+       assertEquals("저장된 태그 내용은 같아야 한다.", "network",getUnitTag.getTag().getContent());
+       assertEquals("저장된 유닛 내용은 같아야 한다.", "double",getUnitTag.getUnit().getTitle());
+   }
+
+}


### PR DESCRIPTION
## PR 요약

1. DoubleUnit, MergedUnit Entity, Repository, Test 추가

## 변경 사항

1. SingleUnit파트를 제외한 나머지 부분 Enity, Repository, Test 를 추가합니다.
2. Test는 SingleUnit이 있다는 전제 하에 만들어 현재 코드로만은 실행되지 않습니다. (혼자서 SingleUnit Class를 만들어 테스트 완료)
3. 데이터 타입 중 'Type'은 사용자 시점 Unit 분류 기준이고 'Form'은 개발자 시점 Unit 분류 기준입니다.
4. Repository는 현재 생성, 단건 조회, 삭제만 가능합니다.

## 클래스 다이어그램
![Untitled Diagram (1)](https://user-images.githubusercontent.com/57346443/184623528-7f30835d-bb81-43b3-a718-2e3227502289.jpg)


## 참고 사항