### PR TITLE
Feat: Logback 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+*.log
+*.properties
+logback-spring.xml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
+    compileOnly 'ch.qos.logback:logback-classic:1.2.11'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mergedoc/backend/filters/LoggingFilter.java
+++ b/src/main/java/com/mergedoc/backend/filters/LoggingFilter.java
@@ -1,0 +1,90 @@
+package com.mergedoc.backend.filters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+    protected static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        MDC.put("traceId", UUID.randomUUID().toString().substring(30));
+        if (isAsyncDispatch(request)) {
+            filterChain.doFilter(request, response);
+        } else {
+            doFilterWrapped(new RequestWrapper(request), new ResponseWrapper(response), filterChain);
+        }
+        MDC.clear();
+    }
+
+    protected void doFilterWrapped(RequestWrapper request, ContentCachingResponseWrapper response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            logRequest(request);
+            filterChain.doFilter(request, response);
+        } finally {
+            logResponse(response);
+            response.copyBodyToResponse();
+        }
+    }
+
+    private static void logRequest(RequestWrapper request) throws IOException {
+        String queryString = request.getQueryString();
+        log.info("Request : {} uri=[{}] content-type=[{}]",
+                request.getMethod(),
+                queryString == null ? request.getRequestURI() : request.getRequestURI() + queryString,
+                request.getContentType()
+        );
+
+        logPayload("Request", request.getContentType(), request.getInputStream());
+    }
+
+    private static void logResponse(ContentCachingResponseWrapper response) throws IOException {
+        log.info("Response '{}'", response.getStatus());
+        logPayload("Response", response.getContentType(), response.getContentInputStream());
+    }
+
+    private static void logPayload(String prefix, String contentType, InputStream inputStream) throws IOException {
+        boolean visible = isVisible(MediaType.valueOf(contentType == null ? "application/json" : contentType));
+        if (visible) {
+            byte[] content = StreamUtils.copyToByteArray(inputStream);
+            if (content.length > 0) {
+                String contentString = new String(content);
+                log.info("{} Payload: {}", prefix, contentString);
+            }
+        } else {
+            log.info("{} Payload: Binary Content", prefix);
+        }
+    }
+
+    private static boolean isVisible(MediaType mediaType) {
+        final List<MediaType> VISIBLE_TYPES = Arrays.asList(
+                MediaType.valueOf("text/*"),
+                MediaType.APPLICATION_FORM_URLENCODED,
+                MediaType.APPLICATION_JSON,
+                MediaType.APPLICATION_XML,
+                MediaType.valueOf("application/*+json"),
+                MediaType.valueOf("application/*+xml"),
+                MediaType.MULTIPART_FORM_DATA
+        );
+
+        return VISIBLE_TYPES.stream()
+                .anyMatch(visibleType -> visibleType.includes(mediaType));
+    }
+}

--- a/src/main/java/com/mergedoc/backend/filters/RequestWrapper.java
+++ b/src/main/java/com/mergedoc/backend/filters/RequestWrapper.java
@@ -1,0 +1,54 @@
+package com.mergedoc.backend.filters;
+
+import org.springframework.util.StreamUtils;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RequestWrapper extends HttpServletRequestWrapper {
+
+    private byte[] cachedInputStream;
+
+    public RequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedInputStream = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new ServletInputStream() {
+            private InputStream cachedBodyInputStream = new ByteArrayInputStream(cachedInputStream);
+
+            @Override
+            public boolean isFinished() {
+                try {
+                    return cachedBodyInputStream.available() == 0;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int read() throws IOException {
+                return cachedBodyInputStream.read();
+            }
+        };
+    }
+}

--- a/src/main/java/com/mergedoc/backend/filters/ResponseWrapper.java
+++ b/src/main/java/com/mergedoc/backend/filters/ResponseWrapper.java
@@ -1,0 +1,11 @@
+package com.mergedoc.backend.filters;
+
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class ResponseWrapper extends ContentCachingResponseWrapper {
+    public ResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+}


### PR DESCRIPTION
## PR 요약

1. 서버 로그를 효과적으로 출력하기 위하여 logback을 적용합니다. (#26) 

## 변경 사항

1. logback 적용

## 참고 사항

1. `/src/main/resources/application.properties` 에서 로그 출력 관련 설정값을 변경할 수 있습니다.
```
spring.profiles.active=local

log.config.path=./
log.config.filename=mergedoc.log
```

2. `build.gradle` 에 `slf4j`와 `logback` 관련 의존성을 추가했습니다
```
dependencies {
    compileOnly 'org.slf4j:slf4j-api:1.7.36'
    compileOnly 'ch.qos.logback:logback-classic:1.2.11'
}
```

3. `/src/main/resources/logback-spring.xml` 파일을 생성하여  logback의 설정을 관리합니다. 해당 파일의 예시는 팀 노션에 업로드 해 두었습니다.